### PR TITLE
 PORTAL-6292 | @jkalberer | Add plural support to babel i18n extractor 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.yarn/
 /.pnp*
+/.vscode/
 
 # Created by https://www.gitignore.io/api/node
 # Edit at https://www.gitignore.io/?templates=node

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,4 +1,4 @@
-import pkg from "./package.json" with { type: "json" };
+import pkg from "./package.json" assert { type: "json" };
 
 import { babel } from "@rollup/plugin-babel";
 import { nodeResolve } from "@rollup/plugin-node-resolve";

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -111,7 +111,7 @@ function getDefaultValue(
         defaultValueKey === key.cleanKey.replace(key.key, ""),
     );
 
-    if (key.parsedOptions.defaultValues.length && foundValue != null) {
+    if (foundValue != null) {
       defaultValue = foundValue[1];
     }
   }

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -83,7 +83,7 @@ function getDefaultValue(
     keyAsDefaultValueEnabled &&
     (keyAsDefaultValueForDerivedKeys || !key.isDerivedKey)
   ) {
-    defaultValue = key.cleanKey;
+    defaultValue = key.key;
   }
 
   const useI18nextDefaultValueEnabled =
@@ -98,6 +98,22 @@ function getDefaultValue(
     (useI18nextDefaultValueForDerivedKeys || !key.isDerivedKey)
   ) {
     defaultValue = key.parsedOptions.defaultValue;
+  }
+
+  // Use defaultValue_somekey
+  if (
+    key.parsedOptions?.defaultValues?.length > 0 &&
+    useI18nextDefaultValueForDerivedKeys &&
+    key.isDerivedKey
+  ) {
+    const foundValue = key.parsedOptions.defaultValues.find(
+      ([defaultValueKey]) =>
+        defaultValueKey === key.cleanKey.replace(key.key, ""),
+    );
+
+    if (key.parsedOptions.defaultValues.length && foundValue != null) {
+      defaultValue = foundValue[1];
+    }
   }
 
   return defaultValue;

--- a/src/extractors/transComponent.ts
+++ b/src/extractors/transComponent.ts
@@ -46,9 +46,11 @@ function parseTransComponentOptions(
   const res: ExtractedKey["parsedOptions"] = {
     contexts: false,
     hasCount: false,
+    ordinal: false,
     keyPrefix: null,
     ns: null,
     defaultValue: null,
+    defaultValues: [], // unused in trans component
   };
 
   const countAttr = findJSXAttributeByName(path, "count");

--- a/tests/__fixtures__/testConfig/defaultValueForDerivedKeys.json
+++ b/tests/__fixtures__/testConfig/defaultValueForDerivedKeys.json
@@ -6,7 +6,7 @@
     "keyAsDefaultValueForDerivedKeys": false
   },
   "expectValues": {
-    "key0_one": "key0_one",
+    "key0_one": null,
     "key0_other": null
   }
 }

--- a/tests/__fixtures__/testConfig/i18nextDefaultValueForDerivedKeysDisabled.json
+++ b/tests/__fixtures__/testConfig/i18nextDefaultValueForDerivedKeysDisabled.json
@@ -3,7 +3,7 @@
   "description": "test that i18next default value is not set for derived keys",
   "pluginOptions": {},
   "expectValues": {
-    "key0_one": "a default value",
+    "key0_one": "",
     "key0_other": ""
   }
 }

--- a/tests/__fixtures__/testPlural/default.js
+++ b/tests/__fixtures__/testPlural/default.js
@@ -1,0 +1,9 @@
+i18next.t("myKey", { count: 22 });
+
+i18next.t("pluralDefaultValues", {
+  count: 22,
+  defaultValue_one: "one",
+  defaultValue_other: "other",
+});
+
+i18next.t("ordinalValues", { count: 22, ordinal: true });

--- a/tests/__fixtures__/testPlural/default.json
+++ b/tests/__fixtures__/testPlural/default.json
@@ -1,0 +1,24 @@
+{
+  "description": "plural tests in different languages",
+  "comment": "ms has 1 plural, en has 2 plurals, ar has 6 plurals",
+  "pluginOptions": {
+    "locales": ["en"]
+  },
+  "expectValues": [
+    [
+      {
+        "myKey_one": "",
+        "myKey_other": "",
+        "ordinalValues_ordinal_few": "",
+        "ordinalValues_ordinal_one": "",
+        "ordinalValues_ordinal_other": "",
+        "ordinalValues_ordinal_two": "",
+        "pluralDefaultValues_one": "",
+        "pluralDefaultValues_other": ""
+      },
+      {
+        "locale": "en"
+      }
+    ]
+  ]
+}

--- a/tests/__fixtures__/testPlural/defaultValueForDerivedKeys.js
+++ b/tests/__fixtures__/testPlural/defaultValueForDerivedKeys.js
@@ -1,0 +1,16 @@
+i18next.t("myKey", { count: 22 });
+
+i18next.t("pluralDefaultValues", {
+  count: 22,
+  defaultValue_one: "custom key one",
+  defaultValue_other: "custom key other",
+});
+
+i18next.t("ordinalValues", {
+  count: 22,
+  ordinal: true,
+  defaultValue_ordinal_few: "custom key few",
+  defaultValue_ordinal_one: "custom key one",
+  defaultValue_ordinal_other: "custom key other",
+  defaultValue_ordinal_two: "custom key two",
+});

--- a/tests/__fixtures__/testPlural/defaultValueForDerivedKeys.json
+++ b/tests/__fixtures__/testPlural/defaultValueForDerivedKeys.json
@@ -1,0 +1,27 @@
+{
+  "description": "plural tests for derived keys",
+  "comment": "if default values have been defined, use them. otherwise fall back to using the key as the default value",
+  "pluginOptions": {
+    "locales": ["en"],
+    "useI18nextDefaultValueForDerivedKeys": true,
+    "keyAsDefaultValue": true,
+    "keyAsDefaultValueForDerivedKeys": true
+  },
+  "expectValues": [
+    [
+      {
+        "myKey_one": "myKey",
+        "myKey_other": "myKey",
+        "ordinalValues_ordinal_few": "custom key few",
+        "ordinalValues_ordinal_one": "custom key one",
+        "ordinalValues_ordinal_other": "custom key other",
+        "ordinalValues_ordinal_two": "custom key two",
+        "pluralDefaultValues_one": "custom key one",
+        "pluralDefaultValues_other": "custom key other"
+      },
+      {
+        "locale": "en"
+      }
+    ]
+  ]
+}

--- a/tests/__fixtures__/testPlural/keyAsDefaultValueForDerivedKeys.js
+++ b/tests/__fixtures__/testPlural/keyAsDefaultValueForDerivedKeys.js
@@ -1,0 +1,16 @@
+i18next.t("myKey", { count: 22 });
+
+i18next.t("pluralDefaultValues", {
+  count: 22,
+  defaultValue_one: "custom key one",
+  defaultValue_other: "custom key other",
+});
+
+i18next.t("ordinalValues", {
+  count: 22,
+  ordinal: true,
+  defaultValue_few: "custom key few",
+  defaultValue_one: "custom key one",
+  defaultValue_other: "custom key other",
+  defaultValue_two: "custom key two",
+});

--- a/tests/__fixtures__/testPlural/keyAsDefaultValueForDerivedKeys.json
+++ b/tests/__fixtures__/testPlural/keyAsDefaultValueForDerivedKeys.json
@@ -1,0 +1,26 @@
+{
+  "description": "plural tests for derived keys",
+  "comment": "if default values have been defined, use them. otherwise fall back to using the key as the default value",
+  "pluginOptions": {
+    "locales": ["en"],
+    "keyAsDefaultValue": true,
+    "keyAsDefaultValueForDerivedKeys": true
+  },
+  "expectValues": [
+    [
+      {
+        "myKey_one": "myKey",
+        "myKey_other": "myKey",
+        "ordinalValues_ordinal_few": "ordinalValues",
+        "ordinalValues_ordinal_one": "ordinalValues",
+        "ordinalValues_ordinal_other": "ordinalValues",
+        "ordinalValues_ordinal_two": "ordinalValues",
+        "pluralDefaultValues_one": "pluralDefaultValues",
+        "pluralDefaultValues_other": "pluralDefaultValues"
+      },
+      {
+        "locale": "en"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
### Internal Release Notes
This PR does a few things

1. Support `count` and `ordinal` for i18n `t` function. _This does not add support on `Trans` components because there wasn't a good example on what properties to set to support defaults_
2. Remove the opinionated logic around `***_one` derived keys. These were being set as "not derived" and given specific logic to populate them with default values. This doesn't make a lot of sense since we generally will want to add values to all derived keys or none of them.
3. Derived keys no longer use `key` instead of `cleanKey` when setting the default value. This means that you'll end up with keys/value mapping
```
"key_one" => "key"
"key_other" => "key"
```
instead of 
```
"key_one" => "key_one"
"key_other" => "key_other"
```
I can't think of any case where I'd want to map the key to value like this. It's better to use the `key` as the fallback because if you have `keyAsDefaultValue` set, you want the keys to actually work as translations.

### Validation Steps
`yarn run test`