### PR TITLE
PORTAL-6292 | @jkalberer | Support plurals with keys and default values

### DIFF
--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -106,9 +106,9 @@ function getDefaultValue(
     useI18nextDefaultValueForDerivedKeys &&
     key.isDerivedKey
   ) {
+    const derivedIdentifier = `${config.pluralSeparator}${key.cleanKey.split(config.pluralSeparator).pop()}`;
     const foundValue = key.parsedOptions.defaultValues.find(
-      ([defaultValueKey]) =>
-        defaultValueKey === key.cleanKey.replace(key.key, ""),
+      ([defaultValueKey]) => defaultValueKey === derivedIdentifier,
     );
 
     if (foundValue != null) {

--- a/src/extractors/tFunction.ts
+++ b/src/extractors/tFunction.ts
@@ -101,7 +101,7 @@ function parseTCallOptions(
         return [
           ...accumulator,
           [
-            key.replace("defaultValue", ""),
+            key.replace("defaultValue", "").replace("_ordinal", ""),
             evaluateIfConfident(node.get("value")),
           ],
         ];
@@ -137,10 +137,20 @@ function extractTCall(
     );
   }
 
+  const tSecondParamValue = evaluateIfConfident(args[1]);
+
+  let parsedTCallOptions;
+  if (typeof tSecondParamValue === "string") {
+    parsedTCallOptions = parseTCallOptions(args[2]);
+    parsedTCallOptions.defaultValue = tSecondParamValue;
+  } else {
+    parsedTCallOptions = parseTCallOptions(args[1]);
+  }
+
   return {
     key: keyEvaluation,
     parsedOptions: {
-      ...parseTCallOptions(args[1]),
+      ...parsedTCallOptions,
       ...parseI18NextOptionsFromCommentHints(path, commentHints),
     },
     sourceNodes: [path.node],

--- a/tests/__fixtures__/testPlural/default.js
+++ b/tests/__fixtures__/testPlural/default.js
@@ -5,5 +5,10 @@ i18next.t("pluralDefaultValues", {
   defaultValue_one: "one",
   defaultValue_other: "other",
 });
+i18next.t("pluralDefaultValues.subkey", "custom key one", {
+  count: 22,
+  defaultValue_one: "custom key one",
+  defaultValue_other: "custom key other",
+});
 
 i18next.t("ordinalValues", { count: 22, ordinal: true });

--- a/tests/__fixtures__/testPlural/default.json
+++ b/tests/__fixtures__/testPlural/default.json
@@ -13,6 +13,10 @@
         "ordinalValues_ordinal_one": "",
         "ordinalValues_ordinal_other": "",
         "ordinalValues_ordinal_two": "",
+        "pluralDefaultValues": {
+          "subkey_one": "",
+          "subkey_other": ""
+        },
         "pluralDefaultValues_one": "",
         "pluralDefaultValues_other": ""
       },

--- a/tests/__fixtures__/testPlural/defaultValueForDerivedKeys.js
+++ b/tests/__fixtures__/testPlural/defaultValueForDerivedKeys.js
@@ -5,6 +5,11 @@ i18next.t("pluralDefaultValues", {
   defaultValue_one: "custom key one",
   defaultValue_other: "custom key other",
 });
+i18next.t("pluralDefaultValues.subkey", "custom key one", {
+  count: 22,
+  defaultValue_one: "custom key one",
+  defaultValue_other: "custom key other",
+});
 
 i18next.t("ordinalValues", {
   count: 22,
@@ -13,4 +18,8 @@ i18next.t("ordinalValues", {
   defaultValue_ordinal_one: "custom key one",
   defaultValue_ordinal_other: "custom key other",
   defaultValue_ordinal_two: "custom key two",
+});
+i18next.t("ordinalValues without Defaults", {
+  count: 22,
+  ordinal: true,
 });

--- a/tests/__fixtures__/testPlural/keyWithDefaultValue.js
+++ b/tests/__fixtures__/testPlural/keyWithDefaultValue.js
@@ -1,0 +1,21 @@
+i18next.t("myKey", "items: {{count}}", { count: 22 });
+
+i18next.t("pluralDefaultValues", "custom key one", {
+  count: 22,
+  defaultValue_one: "custom key one",
+  defaultValue_other: "custom key other",
+});
+i18next.t("pluralDefaultValues.subkey", "custom key one", {
+  count: 22,
+  defaultValue_one: "custom key one",
+  defaultValue_other: "custom key other",
+});
+
+i18next.t("ordinalValues", "custom key one", {
+  count: 22,
+  ordinal: true,
+  defaultValue_few: "custom key few",
+  defaultValue_one: "custom key one",
+  defaultValue_other: "custom key other",
+  defaultValue_two: "custom key two",
+});

--- a/tests/__fixtures__/testPlural/keyWithDefaultValue.json
+++ b/tests/__fixtures__/testPlural/keyWithDefaultValue.json
@@ -3,29 +3,25 @@
   "comment": "if default values have been defined, use them. otherwise fall back to using the key as the default value",
   "pluginOptions": {
     "locales": ["en"],
-    "useI18nextDefaultValueForDerivedKeys": true,
     "keyAsDefaultValue": true,
-    "keyAsDefaultValueForDerivedKeys": true
+    "keyAsDefaultValueForDerivedKeys": true,
+    "useI18nextDefaultValueForDerivedKeys": true
   },
   "expectValues": [
     [
       {
-        "myKey_one": "myKey",
-        "myKey_other": "myKey",
-        "ordinalValues without Defaults_ordinal_few": "ordinalValues without Defaults",
-        "ordinalValues without Defaults_ordinal_one": "ordinalValues without Defaults",
-        "ordinalValues without Defaults_ordinal_other": "ordinalValues without Defaults",
-        "ordinalValues without Defaults_ordinal_two": "ordinalValues without Defaults",
+        "myKey_one": "items: {{count}}",
+        "myKey_other": "items: {{count}}",
         "ordinalValues_ordinal_few": "custom key few",
         "ordinalValues_ordinal_one": "custom key one",
         "ordinalValues_ordinal_other": "custom key other",
         "ordinalValues_ordinal_two": "custom key two",
+        "pluralDefaultValues_one": "custom key one",
+        "pluralDefaultValues_other": "custom key other",
         "pluralDefaultValues": {
           "subkey_one": "custom key one",
           "subkey_other": "custom key other"
-        },
-        "pluralDefaultValues_one": "custom key one",
-        "pluralDefaultValues_other": "custom key other"
+        }
       },
       {
         "locale": "en"

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -16,6 +16,8 @@ export function createTranslationKey(
       keyPrefix: null,
       ns: null,
       defaultValue: null,
+      ordinal: false,
+      defaultValues: [],
     },
     cleanKey: key,
     ns: "translation",


### PR DESCRIPTION
### Internal Release Notes
This fixed a bug where the extractor didn't work when the second parameter was the default value.

I also updated some tests because they actually had the wrong value for some things.

### Validation Steps
`yarn run test`


Copied the bits into Portal

Before:
![image](https://github.com/user-attachments/assets/84428ca7-feca-4538-8760-521eaf15fcaa)

After: 
![image](https://github.com/user-attachments/assets/3bd5a209-fb6f-40d3-b29c-1da27fb65cf2)
