### PR TITLE
PORTAL-6292 | @jkalberer | Add extraction for class members with the i18n object

### DIFF
--- a/src/extractors/getClassMember.ts
+++ b/src/extractors/getClassMember.ts
@@ -1,0 +1,67 @@
+import * as BabelCore from "@babel/core";
+import * as BabelTypes from "@babel/types";
+
+import { CommentHint, getCommentHintForPath } from "../comments";
+import { Config } from "../config";
+import { ExtractedKey } from "../keys";
+
+import { findTFunctionCallsInClassComponent } from "./commons";
+import extractTFunction from "./tFunction";
+
+/**
+ * Parse function or class declaration (likely components) to find whether
+ * they are wrapped with "withTranslation()" HOC, and if so, extract all the
+ * translations that come from the "t" function injected in the component
+ * properties.
+ *
+ * @param path node path to the component
+ * @param config plugin configuration
+ * @param commentHints parsed comment hints
+ */
+export default function extractGetClassMember(
+  path: BabelCore.NodePath<BabelTypes.Function | BabelTypes.ClassDeclaration>,
+  config: Config,
+  commentHints: CommentHint[] = [],
+): ExtractedKey[] {
+  if (!path.isClassDeclaration()) {
+    return [];
+  }
+  const tCalls = config.i18nextInstanceNames.reduce(
+    (accumulator, instanceName) => [
+      ...accumulator,
+      ...findTFunctionCallsInClassComponent(path, instanceName),
+    ],
+    [] as BabelCore.NodePath<BabelTypes.CallExpression>[],
+  );
+
+  // Extract namespace
+  let ns: string | null;
+  const nsCommentHint = getCommentHintForPath(path, "NAMESPACE", commentHints);
+  if (nsCommentHint) {
+    // We got a comment hint, take its value as namespace.
+    ns = nsCommentHint.value;
+  } else {
+    // TODO - extract from constructor parameter with reflection
+  }
+
+  let keys = Array<ExtractedKey>();
+  for (const tCall of tCalls) {
+    keys = [
+      ...keys,
+      ...extractTFunction(tCall, config, commentHints, true).map((k) => ({
+        // Add namespace if it was not explicitely set in t() call.
+        ...k,
+        parsedOptions: {
+          ...k.parsedOptions,
+          ns: k.parsedOptions.ns || ns,
+        },
+      })),
+    ];
+  }
+
+  return keys.map((k) => ({
+    ...k,
+    sourceNodes: [path.node, ...k.sourceNodes],
+    extractorName: extractGetClassMember.name,
+  }));
+}

--- a/src/extractors/index.ts
+++ b/src/extractors/index.ts
@@ -1,6 +1,7 @@
 import { ExtractionError } from "./commons";
 import extractCustomTransComponent from "./customTransComponent";
 import extractCustomUseTranslationHook from "./customUseTranslationHook";
+import extractGetClassMember from "./getClassMember";
 import extractGetFixedTFunction from "./getFixedTFunction";
 import extractI18nextInstance from "./i18nextInstance";
 import extractTFunction from "./tFunction";
@@ -22,6 +23,7 @@ export const EXTRACTORS_PRIORITIES = [
   extractGetFixedTFunction.name,
   extractTranslationRenderProp.name,
   extractWithTranslationHOC.name,
+  extractGetClassMember.name,
   extractI18nextInstance.name,
   extractTFunction.name,
 ];
@@ -34,6 +36,7 @@ export default {
   extractGetFixedTFunction,
   extractTranslationRenderProp,
   extractWithTranslationHOC,
+  extractGetClassMember,
   extractI18nextInstance,
   extractTFunction,
 };

--- a/src/extractors/withTranslationHOC.ts
+++ b/src/extractors/withTranslationHOC.ts
@@ -9,6 +9,8 @@ import {
   getFirstOrNull,
   evaluateIfConfident,
   referencesImport,
+  findTFunctionCallsInClassComponent,
+  findTFunctionCallsFromPropsAssignment,
 } from "./commons";
 import extractTFunction from "./tFunction";
 
@@ -149,159 +151,6 @@ function findWithTranslationHOCCallExpression(
 }
 
 /**
- * Try to find "t" in an object spread. Useful when looking for the "t" key
- * in a spread object. e.g. const {t} = props;
- *
- * @param path object pattern
- * @returns t identifier or null of it was not found in the object pattern.
- */
-function findTFunctionIdentifierInObjectPattern(
-  path: BabelCore.NodePath<BabelTypes.ObjectPattern>,
-): BabelCore.NodePath<BabelTypes.Identifier> | null {
-  const props = path.get("properties");
-
-  for (const prop of props) {
-    if (prop.isObjectProperty()) {
-      const key = prop.get("key");
-      if (!Array.isArray(key) && key.isIdentifier() && key.node.name === "t") {
-        return key;
-      }
-    }
-  }
-
-  return null;
-}
-
-/**
- * Check whether a node path is the callee of a call expression.
- *
- * @param path the node to check.
- * @returns true if the path is the callee of a call expression.
- */
-function isCallee(path: BabelCore.NodePath): path is BabelCore.NodePath & {
-  parentPath: BabelCore.NodePath<BabelTypes.CallExpression>;
-} {
-  return !!(
-    path.parentPath?.isCallExpression() &&
-    path === path.parentPath.get("callee")
-  );
-}
-
-/**
- * Find T function calls from a props assignment. Prop assignment can occur
- * in function parameters (i.e. "function Component(props)" or
- * "function Component({t})") or in a variable declarator (i.e.
- * "const props = …" or "const {t} = props").
- *
- * @param propsId identifier for the prop assignment. e.g. "props" or "{t}"
- * @returns Call expressions to t function.
- */
-function findTFunctionCallsFromPropsAssignment(
-  propsId: BabelCore.NodePath,
-): BabelCore.NodePath<BabelTypes.CallExpression>[] {
-  const tReferences = Array<BabelCore.NodePath>();
-
-  const body = propsId.parentPath?.get("body");
-  if (body === undefined || Array.isArray(body)) return [];
-  const scope = body.scope;
-
-  if (propsId.isObjectPattern()) {
-    // got "function MyComponent({t, other, props})"
-    // or "const {t, other, props} = this.props"
-    // we want to find references to "t"
-    const tFunctionIdentifier = findTFunctionIdentifierInObjectPattern(propsId);
-    if (tFunctionIdentifier === null) return [];
-    const tBinding = scope.bindings[tFunctionIdentifier.node.name];
-    tReferences.push(...tBinding.referencePaths);
-  } else if (propsId.isIdentifier()) {
-    // got "function MyComponent(props)"
-    // or "const props = this.props"
-    // we want to find references to props.t
-    const references = scope.bindings[propsId.node.name].referencePaths;
-    for (const reference of references) {
-      if (reference.parentPath?.isMemberExpression()) {
-        const prop = reference.parentPath.get("property");
-        if (
-          !Array.isArray(prop) &&
-          prop.isIdentifier() &&
-          prop.node.name === "t"
-        ) {
-          tReferences.push(reference.parentPath);
-        }
-      }
-    }
-  }
-
-  // We have candidates. Let's see if t references are actual calls to the t
-  // function
-  const tCalls = Array<BabelCore.NodePath<BabelTypes.CallExpression>>();
-  for (const tCall of tReferences) {
-    if (isCallee(tCall)) {
-      tCalls.push(tCall.parentPath);
-    }
-  }
-
-  return tCalls;
-}
-
-/**
- * Find all t function calls in a class component.
- * @param path node path to the class component.
- */
-function findTFunctionCallsInClassComponent(
-  path: BabelCore.NodePath<BabelTypes.ClassDeclaration>,
-): BabelCore.NodePath<BabelTypes.CallExpression>[] {
-  const result = Array<BabelCore.NodePath<BabelTypes.CallExpression>>();
-
-  const thisVisitor: BabelCore.Visitor = {
-    ThisExpression(path) {
-      if (!path.parentPath.isMemberExpression()) return;
-
-      const propProperty = path.parentPath.get("property");
-      if (Array.isArray(propProperty) || !propProperty.isIdentifier()) return;
-      if (propProperty.node.name !== "props") return;
-
-      // Ok, this is interesting, we have something with "this.props"
-
-      if (path.parentPath.parentPath.isMemberExpression()) {
-        // We have something in the form "this.props.xxxx".
-
-        const tIdentifier = path.parentPath.parentPath.get("property");
-        if (Array.isArray(tIdentifier) || !tIdentifier.isIdentifier()) return;
-        if (tIdentifier.node.name !== "t") return;
-
-        // We have something in the form "this.props.t". Let's see if it's an
-        // actual function call or an assignment.
-        const tExpression = path.parentPath.parentPath;
-        if (isCallee(tExpression)) {
-          // Simple case. Direct call to "this.props.t()"
-          result.push(tExpression.parentPath);
-        } else if (tExpression.parentPath.isVariableDeclarator()) {
-          // Hard case. const t = this.props.t;
-          // Let's loop through all references to t.
-          const id = tExpression.parentPath.get("id");
-          if (!id.isIdentifier()) return;
-          for (const reference of id.scope.bindings[id.node.name]
-            .referencePaths) {
-            if (isCallee(reference)) {
-              result.push(reference.parentPath);
-            }
-          }
-        }
-      } else if (path.parentPath.parentPath.isVariableDeclarator()) {
-        // We have something in the form "const props = this.props"
-        // Or "const {t} = this.props"
-        const id = path.parentPath.parentPath.get("id");
-        result.push(...findTFunctionCallsFromPropsAssignment(id));
-      }
-    },
-  };
-  path.traverse(thisVisitor);
-
-  return result;
-}
-
-/**
  * Find t function calls in a function component.
  * @param path node path to the function component.
  */
@@ -335,7 +184,7 @@ export default function extractWithTranslationHOC(
 
   let tCalls: BabelCore.NodePath<BabelTypes.CallExpression>[];
   if (path.isClassDeclaration()) {
-    tCalls = findTFunctionCallsInClassComponent(path);
+    tCalls = findTFunctionCallsInClassComponent(path, "props");
   } else {
     tCalls = findTFunctionCallsInFunctionComponent(
       path as BabelCore.NodePath<BabelTypes.Function>,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,6 +11,7 @@ import Extractors, {
   EXTRACTORS_PRIORITIES,
   ExtractionError,
 } from "./extractors";
+import extractGetClassMember from "./extractors/getClassMember";
 import extractWithTranslationHOC from "./extractors/withTranslationHOC";
 import { computeDerivedKeys, ExtractedKey, TranslationKey } from "./keys";
 
@@ -175,6 +176,13 @@ const Visitor: BabelCore.Visitor<VisitorState> = {
     handleExtraction(path, state, (collect) => {
       collect(
         extractWithTranslationHOC(
+          path,
+          extractState.config,
+          extractState.commentHints,
+        ),
+      );
+      collect(
+        extractGetClassMember(
           path,
           extractState.config,
           extractState.commentHints,

--- a/tests/__fixtures__/testGetClassMember/customInstanceName.js
+++ b/tests/__fixtures__/testGetClassMember/customInstanceName.js
@@ -1,0 +1,16 @@
+class Clazz1 {
+  getTranslation() {
+    return this.pgm.t("key1", "some value");
+  }
+}
+
+class Clazz2 {
+  getTranslation() {
+    return this._.t("key2", "some value");
+  }
+}
+class Clazz3 {
+  getTranslation() {
+    return this.foo.t("key3", "some value");
+  }
+}

--- a/tests/__fixtures__/testGetClassMember/customInstanceName.json
+++ b/tests/__fixtures__/testGetClassMember/customInstanceName.json
@@ -1,0 +1,10 @@
+{
+  "description": "test giving custom instance name to i18next",
+  "pluginOptions": {
+    "i18nextInstanceNames": ["pgm", "_"]
+  },
+  "expectValues": {
+    "key1": "some value",
+    "key2": "some value"
+  }
+}

--- a/tests/__fixtures__/testGetClassMember/namespace.js
+++ b/tests/__fixtures__/testGetClassMember/namespace.js
@@ -1,0 +1,20 @@
+/*
+  i18next-extract-mark-ns-next-line secret-ns
+*/
+class Clazz1 {
+  getTranslation() {
+    return this.i18n.t("key", "some value");
+  }
+}
+
+class Clazz2 {
+  getTranslation() {
+    return this.i18n.t("key", "some value", { ns: "secret-ns-2" });
+  }
+}
+
+class Clazz3 {
+  getTranslation() {
+    return this.i18n.t("secret-ns-3:key", "some value");
+  }
+}

--- a/tests/__fixtures__/testGetClassMember/namespace.json
+++ b/tests/__fixtures__/testGetClassMember/namespace.json
@@ -1,0 +1,9 @@
+{
+  "description": "test simple extractions of getClassMember with namespace set",
+  "pluginOptions": {},
+  "expectValues": [
+    [{ "key": "some value" }, { "ns": "secret-ns" }],
+    [{ "key": "some value" }, { "ns": "secret-ns-2" }],
+    [{ "key": "some value" }, { "ns": "secret-ns-3" }]
+  ]
+}


### PR DESCRIPTION
### Internal Release Notes
This will add support for dependency injection in things like NestJS where we are injecting the `i18n` instance we're using as a service.

_This implementation only supports namespaces by adding them at the class level, passing the namespace in the key, or via the `ns` property when calling `this.i18n.t(...)`._

### Validation Steps
`yarn run test`