### PR TITLE
NOJIRA | @dmoxon | Try standard AE publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,47 +1,16 @@
 name: NPM Publish
 on:
   workflow_dispatch:
-    inputs:
-      version_type:
-        description: 'Version bump type'
-        required: false
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+  push:
+    branches: [master]
 
 permissions: write-all
 
+concurrency: babel-plugin-publish
+
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Bump version
-        run: npm version ${{ github.event.inputs.version_type || 'patch' }} --no-git-tag-version
-
-      - name: Run tests and build
-        run: yarn run check && yarn run build
-
-      - name: Bump version and publish
-        run: |
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # For scoped packages add: NPM_CONFIG_ACCESS: public
-    
+    # don't run on lerna publish commits
+    if: ${{ ! contains(github.event.head_commit.message, 'chore(lerna)') }}
+    uses: audioeye/github-actions/.github/workflows/publish-packages.yml@main
+    secrets: inherit


### PR DESCRIPTION
### TL;DR

Simplified the NPM publish workflow by using a reusable workflow from the audioeye/github-actions repository.

### What changed?

- Removed manual implementation of the publish workflow
- Added automatic triggering on pushes to the master branch
- Added concurrency control to prevent parallel publish jobs
- Added a condition to skip publishing for lerna commit messages
- Replaced the custom implementation with a reference to a reusable workflow from audioeye/github-actions

### How to test?

1. Push a commit to the master branch and verify that the workflow runs automatically
2. Create a commit with a message containing "chore(lerna)" and verify that the workflow is skipped
3. Manually trigger the workflow from the GitHub Actions tab

### Why make this change?

This change standardizes the publishing process by using a centralized workflow definition, reducing maintenance overhead and ensuring consistency across repositories. The reusable workflow likely contains best practices and optimizations that can be shared across multiple projects.